### PR TITLE
fix(manifest): correct sync levels for scripts and mega-linter

### DIFF
--- a/sync-manifest.yml
+++ b/sync-manifest.yml
@@ -15,7 +15,7 @@ configs:
   .hadolint.yaml:          { sync: all }
   .jscpd.json:             { sync: all }
   .markdownlint-cli2.yaml: { sync: all }
-  .mega-linter.yml:        { sync: opt-in }
+  .mega-linter.yml:        { sync: all }
   .pre-commit-config.yaml: { sync: all }
   .prettierrc:             { sync: all }
   .shellcheckrc:           { sync: all }
@@ -35,9 +35,9 @@ workflows:
 
 scripts:
   check-manifest-coverage.py: { sync: none }
-  compact-run:                { sync: none }
-  git-commit-msg.sh:          { sync: none }
-  git-post-commit.sh:         { sync: none }
-  git-pre-commit.sh:          { sync: none }
-  git-pre-push.sh:            { sync: none }
-  setup-hooks.sh:             { sync: none }
+  compact-run:                { sync: all }
+  git-commit-msg.sh:          { sync: all }
+  git-post-commit.sh:         { sync: all }
+  git-pre-commit.sh:          { sync: all }
+  git-pre-push.sh:            { sync: all }
+  setup-hooks.sh:             { sync: all }


### PR DESCRIPTION
## Summary

- Mark 6 scripts (hook wrappers + compact-run + setup-hooks.sh) as `sync: all` — they were incorrectly marked `sync: none` but are actively synced to consumer repos
- Fix `.mega-linter.yml` from `opt-in` to `all` to match actual sync behavior
- `check-manifest-coverage.py` remains `sync: none` (genuinely local-only)

Prep for issue #33 (generate sync.yml from manifest) — the manifest must accurately reflect what's synced before we can generate from it.

## Test plan

- [x] `just test` passes (55 tests)
- [x] `uv run --with pyyaml scripts/check-manifest-coverage.py` passes