### PR TITLE
fix: entrypoint symlinks baked config for EXTENDS support

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
-# Smart config resolution: workspace config takes precedence over baked default.
-# Consumer repos just drop a .mega-linter.yml in their root — no flags needed.
+# Smart config resolution for coding-standards Docker image.
+#
+# 1. Always symlink the baked default into workspace so EXTENDS can reference it
+# 2. If workspace has .mega-linter.yml, use it (can EXTENDS .coding-standards-defaults.yml)
+# 3. Otherwise use the baked default directly
+
+# Make baked config available in workspace for EXTENDS
+ln -sf /opt/coding-standards/.mega-linter.yml /tmp/lint/.coding-standards-defaults.yml
+
 if [ -f /tmp/lint/.mega-linter.yml ]; then
   export MEGALINTER_CONFIG="/tmp/lint/.mega-linter.yml"
 else


### PR DESCRIPTION
Consumer configs with EXTENDS now work. Found during home-network deployment — EXTENDS only resolves workspace-relative paths.