### PR TITLE
fix: add CVE-2026-30836 to trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,4 @@ DS-0026
 CVE-2025-68121  # crypto/tls: session resumption (Go stdlib, fixed in 1.24.13+)
 CVE-2026-33186  # gRPC-Go: authorization bypass (fixed in 1.79.3)
 CVE-2024-45337  # golang.org/x/crypto/ssh: misuse (fixed in 0.31.0)
+CVE-2026-30836  # smallstep/certificates: SCEP unauthenticated issuance (in megalinter base image)


### PR DESCRIPTION
## Summary
- Add CVE-2026-30836 (smallstep/certificates SCEP unauthenticated issuance) to .trivyignore

Upstream dependency in the MegaLinter base image — we can't rebuild it. Unblocks the Docker build that failed on merge of #23.