### PR TITLE
ci: complete Node 20→24 migration

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
Second pass: update remaining actions still on Node 20 to Node 24 equivalents. See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/