### PR TITLE
fix: async def coverage + EXTENDS docs clarification

### DIFF
--- a/docs/config-decisions.md
+++ b/docs/config-decisions.md
@@ -66,7 +66,7 @@ Decisions made 2026-03-29. Revisit if assumptions change.
 
 - MegaLinter's EXTENDS mechanism **merges** arrays instead of replacing them.
 - A consumer setting `REPOSITORY_SEMGREP_RULESETS: [auto]` gets `[auto, p/trailofbits, /opt/.../semgrep-rules/, auto]` — duplicated and with corrupted relative paths.
-- Consumer repos should NOT override array-valued keys that contain absolute image paths. Either omit (inherit baseline) or replace completely with only workspace-relative values.
+- Consumer repos should NOT override array-valued keys containing absolute image paths when using EXTENDS. Either omit (inherit baseline as-is) or stop using EXTENDS and copy the baseline config locally.
 
 ### Added from audit
 

--- a/semgrep-rules/python-typing.yml
+++ b/semgrep-rules/python-typing.yml
@@ -1,8 +1,11 @@
 rules:
   - id: no-bare-dict-params
-    patterns:
+    pattern-either:
       - pattern: |
           def $FUNC(..., $PARAM: dict, ...):
+              ...
+      - pattern: |
+          async def $FUNC(..., $PARAM: dict, ...):
               ...
     message: >
       Use a TypedDict or specific dict[K, V] instead of bare `dict`.
@@ -15,9 +18,12 @@ rules:
       technology: [python]
 
   - id: no-bare-dict-return
-    patterns:
+    pattern-either:
       - pattern: |
           def $FUNC(...) -> dict:
+              ...
+      - pattern: |
+          async def $FUNC(...) -> dict:
               ...
     message: >
       Use a TypedDict or specific dict[K, V] instead of bare `dict` return.


### PR DESCRIPTION
## Summary

Fixes pushed to PR #30 branch after squash merge — these didn't make it into main.

- Add `async def` variants to bare-dict semgrep rules via `pattern-either`
- Clarify EXTENDS array merge workaround in config-decisions docs