### PR TITLE
fix: regenerate catalog + remove dive from build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 # CI — two-tier feedback.
-#   1. Fast checks (~15s): ruff, conftest, semgrep, pytest, pre-commit
+#   1. Fast checks (~15s): ruff, conftest, semgrep, pytest, pre-commit, drift checks
 #   2. Image self-lint (via composite action): runs the published image
 name: CI
 
@@ -43,6 +43,12 @@ jobs:
 
       - name: Pytest
         run: uv run --with pydantic --with pyyaml --with pytest pytest test/ -v
+
+      - name: Catalog drift check
+        run: uv run --with pydantic --with pyyaml python3 scripts/generate-catalog.py --check
+
+      - name: CI smoke test coverage check
+        run: python3 scripts/hooks/check-ci-json-coverage
 
       - name: Pre-commit
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -119,14 +119,6 @@ jobs:
           scanners: vuln
           trivyignores: .trivyignore
 
-      # Image efficiency check — catch wasted space in layers
-      - name: Dive layer analysis
-        run: |
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            wagoodman/dive@sha256:f1886e6c32c094fc41a623c1989f5cb3e48aa766da5f0be233f911fc1d85ce10 \
-            --ci --lowestEfficiency=0.9 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-test || true
-
       # Smoke test — verify all custom tools from .ci.json
       - name: Smoke test
         run: |

--- a/.github/workflows/image-analysis.yml
+++ b/.github/workflows/image-analysis.yml
@@ -1,0 +1,23 @@
+---
+# Weekly image analysis — dive layer efficiency check.
+# Runs against :latest, reports wasted space. Non-blocking.
+name: Image Analysis
+
+on:
+  schedule:
+    - cron: "23 3 * * 1" # Monday 03:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dive layer analysis
+        run: |
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+            wagoodman/dive@sha256:f1886e6c32c094fc41a623c1989f5cb3e48aa766da5f0be233f911fc1d85ce10 \
+            --ci --lowestEfficiency=0.9 \
+            ghcr.io/alxleo/coding-standards:latest 2>&1 | tail -20


### PR DESCRIPTION
Catalog drift check failed because import-linter plugin descriptor changed without regeneration. Dive removed — too slow (pulls image every run) and too noisy (dumps all layers to stdout).