### PR TITLE
ci: add weekly maintenance workflow

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,44 @@
+# Weekly maintenance: update GitHub Actions to latest versions.
+name: Maintenance
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update actions
+        run: npx --yes actions-up --yes
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR
+        if: steps.diff.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="maintenance/update-actions-$(date +%Y%m%d)"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "ci: update GitHub Actions versions"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "ci: update GitHub Actions versions" \
+            --body "Automated weekly action version bump. Node 20 retirement: June 2026." \
+            --draft


### PR DESCRIPTION
Automated weekly action version bumps via actions-up. Node 20 retirement: June 2026.