### PR TITLE
ci: add weekly buildkit cache prune to scheduled workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -100,8 +100,9 @@ jobs:
           gh cache list --repo "$REPO" --limit 500 --json id,key \
             --jq '.[] | select(.key | startswith("buildkit-")) | .id' |
             xargs -I {} gh cache delete {} --repo "$REPO" 2>/dev/null || true
-          echo "Remaining caches:"
-          gh cache list --repo "$REPO" --limit 500 --json key --jq '. | length'
+          remaining=$(gh cache list --repo "$REPO" --limit 500 --json key \
+            --jq '[.[] | select(.key | startswith("buildkit-"))] | length' 2>/dev/null || echo "?")
+          echo "Remaining buildkit caches: $remaining"
 
   # Dive layer efficiency — non-blocking
   dive:


### PR DESCRIPTION
## Summary

Missed the merge window on PR #92 — this commit was pushed after the squash-merge.

Adds a `cache-prune` job to the weekly scheduled workflow that deletes any residual buildkit blob caches. Safety net for the `type=registry` switch in #92.

## Test plan
- [x] `just check` passes (actionlint, zizmor validate)
- [ ] CI validates workflow syntax