### PR TITLE
fix: resolve consumer _CONFIG_FILE overrides to workspace paths

### DIFF
--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -35,7 +35,7 @@ def _workspace() -> Path:
     return Path(os.environ.get("DEFAULT_WORKSPACE", "/tmp/lint"))
 
 
-def _resolve_config_overrides(overrides: dict, workspace: Path) -> None:
+def _resolve_config_overrides(overrides: dict[str, object], workspace: Path) -> None:
     """Rewrite _CONFIG_FILE overrides to workspace-absolute paths."""
     workspace_resolved = workspace.resolve()
     for key, value in overrides.items():

--- a/test/test_entrypoint_config.py
+++ b/test/test_entrypoint_config.py
@@ -18,9 +18,7 @@ def workspace(tmp_path):
     baked.write_text(yaml.dump({"ENABLE_LINTERS": "PYTHON_RUFF"}))
 
     # Patch constants
-    with patch("scripts.entrypoint.BAKED_CONFIG", baked), patch(
-        "scripts.entrypoint._workspace", return_value=tmp_path
-    ):
+    with patch("scripts.entrypoint.BAKED_CONFIG", baked), patch("scripts.entrypoint._workspace", return_value=tmp_path):
         yield tmp_path
 
 
@@ -59,9 +57,7 @@ class TestConfigFileResolution:
 
     def test_path_traversal_rejected(self, workspace):
         """../../etc/passwd traversal is blocked by is_relative_to check."""
-        _write_consumer_config(
-            workspace, {"PYTHON_RUFF_CONFIG_FILE": "../../etc/passwd"}
-        )
+        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "../../etc/passwd"})
 
         _run_setup()
 
@@ -71,26 +67,20 @@ class TestConfigFileResolution:
 
     def test_missing_file_produces_warning(self, workspace, capsys):
         """Missing file within workspace produces a stderr warning."""
-        _write_consumer_config(
-            workspace, {"PYTHON_RUFF_CONFIG_FILE": "nonexistent.toml"}
-        )
+        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "nonexistent.toml"})
 
         _run_setup()
 
         merged = _read_merged_config()
         # Not rewritten since file doesn't exist
-        assert merged.get("PYTHON_RUFF_CONFIG_FILE") != str(
-            workspace / "nonexistent.toml"
-        )
+        assert merged.get("PYTHON_RUFF_CONFIG_FILE") != str(workspace / "nonexistent.toml")
 
         captured = capsys.readouterr()
         assert "Warning: PYTHON_RUFF_CONFIG_FILE override points to missing file" in captured.err
 
     def test_absolute_path_not_modified(self, workspace):
         """Absolute paths are left as-is (consumer knows what they're doing)."""
-        _write_consumer_config(
-            workspace, {"PYTHON_RUFF_CONFIG_FILE": "/opt/custom/ruff.toml"}
-        )
+        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "/opt/custom/ruff.toml"})
 
         _run_setup()
 
@@ -99,9 +89,7 @@ class TestConfigFileResolution:
 
     def test_non_config_file_keys_not_modified(self, workspace):
         """Keys that don't end in _CONFIG_FILE are left alone."""
-        _write_consumer_config(
-            workspace, {"PYTHON_RUFF_ARGUMENTS": ["--fix"]}
-        )
+        _write_consumer_config(workspace, {"PYTHON_RUFF_ARGUMENTS": ["--fix"]})
 
         _run_setup()
 


### PR DESCRIPTION
## Summary

When a consumer repo uses EXTENDS in `.mega-linter.yml` and overrides a `_CONFIG_FILE` setting (e.g. `PYTHON_RUFF_CONFIG_FILE: ruff.toml`), the entrypoint's merge correctly puts it in the merged config but MegaLinter resolves relative paths against the baked configs directory, not the workspace.

Fix: after merging, resolve consumer `_CONFIG_FILE` overrides to absolute workspace paths before writing the merged config.

**Before:** `PYTHON_RUFF_CONFIG_FILE: ruff.toml` → MegaLinter finds `/opt/coding-standards/configs/ruff.toml`
**After:** `PYTHON_RUFF_CONFIG_FILE: /tmp/lint/ruff.toml` → MegaLinter finds the consumer's `ruff.toml`

## Test plan

- [x] 172 tests pass
- [ ] Build image and test with local-cicd repo (consumer has `ruff.toml` with per-file-ignores for Click commands)