### PR TITLE
fix: narrow silent-fallback-or to .get() sinks only

### DIFF
--- a/semgrep-rules/silent-fallbacks.yml
+++ b/semgrep-rules/silent-fallbacks.yml
@@ -1,22 +1,17 @@
 rules:
   - id: coding-standards.python-silent-fallback-or
     patterns:
-      - pattern: $X or $DEFAULT
-      # Exclude boolean logic — two comparisons joined by or
-      - pattern-not: $A == $B or $C == $D
-      - pattern-not: $A != $B or $C != $D
-      - pattern-not: $A < $B or $C < $D
-      - pattern-not: $A > $B or $C > $D
-      - pattern-not: $A in $B or $C in $D
-      - pattern-not: $A is $B or $C is $D
-      # Exclude any() which is the idiomatic replacement
+      - pattern-either:
+          - pattern: $OBJ.get(...) or $DEFAULT
+          - pattern: os.environ.get(...) or $DEFAULT
+          - pattern: os.getenv(...) or $DEFAULT
       - pattern-not: any(...)
     message: >
-      Silent fallback: `or $DEFAULT` may hide a bug.
-      Idiomatic fixes (don't suppress — refactor instead):
+      Silent fallback: `.get() or $DEFAULT` treats falsy values (0, "", [])
+      the same as missing keys. Use the default parameter instead:
         - dict.get(key) or [] → dict.get(key, [])
-        - x or default_value → if/else or any()
-        - check_a() or check_b() → any((check_a(), check_b()))
+        - os.environ.get("K") or "v" → os.environ.get("K", "v")
+        - os.getenv("K") or "v" → os.getenv("K", "v")
       Last resort: `# nosemgrep: python-silent-fallback-or`
     languages: [python]
     severity: INFO


### PR DESCRIPTION
## Summary

- Replaced broad `$X or $DEFAULT` semgrep pattern (matched every `or` in Python) with targeted `.get()` sink patterns
- Now only flags `dict.get()`, `os.environ.get()`, and `os.getenv()` followed by `or` — the actual falsy-value bug
- Eliminates false positives on boolean logic (`if enabled or force:`, `return a or b`, etc.)
- Updated message to explain *why* it's a bug (falsy values treated as missing keys)

## Test plan

- [x] `semgrep --validate` passes
- [x] Smoke test: 4/4 true positives on `.get() or` patterns, 0 FP on boolean logic
- [x] Clean scan across all 22 Python files in `scripts/`
- [x] `just check` passes