### PR TITLE
fix: restore coding standards checks

### DIFF
--- a/.mega-linter-default.yml
+++ b/.mega-linter-default.yml
@@ -144,6 +144,8 @@ DISABLE_ERRORS_LINTERS:
 # shellcheck: --rcfile points at .mega-linter-config/.shellcheckrc (no root pollution).
 BASH_SHELLCHECK_ARGUMENTS:
   - "--rcfile=.mega-linter-config/.shellcheckrc"
+# Semgrep rule fixtures intentionally contain invalid shell snippets.
+BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: "semgrep-rules/.*\\.sh"
 # editorconfig-checker: .editorconfig MUST be at project root per EditorConfig spec.
 # The -config flag is for .ecrc (tool config), not .editorconfig. Stays in PRE_COMMANDS root copy.
 # rumdl: custom plugin with cli_config_arg_name: --config. Clean _CONFIG_FILE.

--- a/Dockerfile
+++ b/Dockerfile
@@ -244,9 +244,9 @@ RUN set -eux && \
   chmod +x /usr/local/bin/caddy && \
   rm /tmp/caddy.tar.gz && \
   # ── just (task runner) ──
-  JUST_VERSION="1.48.1" && \
-  JUST_SHA256_amd64="9293e553ce401d1b524bf4e104918f72f268e3f9c6827e0055fe98d84a1b2522" && \
-  JUST_SHA256_arm64="3308721b991cf88cf2b9bbb3b31ac40550ec61a0c9b6fc011564e25e87964030" && \
+  JUST_VERSION="1.57.0" && \
+  JUST_SHA256_amd64="45b548094283cb9739af8f13273b8cddeee869f5b4ef2bb631b1f311cb566155" && \
+  JUST_SHA256_arm64="f225044a81adea6e0b3a8b9370aaf374e6af76c8735ae263ac993df55fd137ec" && \
   JUST_SHA256=$([ "$TARGETARCH" = "arm64" ] && echo "$JUST_SHA256_arm64" || echo "$JUST_SHA256_amd64") && \
   JUST_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
   curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@
 #   just lint     — full MegaLinter suite via Docker image
 #   just verify   — both: check + lint + rego tests
 
-set unstable := true
+set unstable
 
 image := "coding-standards:test"
 docker_args := '-v "$PWD:/tmp/lint" -e DEFAULT_WORKSPACE=/tmp/lint'

--- a/lint-configs/.pre-commit-config.yaml
+++ b/lint-configs/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
 
       - id: semgrep-scan
         name: Semgrep scan (custom rules)
-        entry: uvx semgrep scan --config semgrep-rules/ --error --quiet
+        entry: uvx semgrep scan --config semgrep-rules/ --exclude=semgrep-rules/*.sh --error --quiet
         language: system
         pass_filenames: false
         types_or: [python, javascript, ts, yaml, bash]

--- a/lint-configs/.pre-commit-config.yaml
+++ b/lint-configs/.pre-commit-config.yaml
@@ -147,8 +147,10 @@ repos:
   - repo: local
     hooks:
       - id: semgrep-validate
-        name: Validate semgrep rules
-        entry: uvx semgrep scan --config semgrep-rules/ --validate
+        name: Validate and test semgrep rules
+        entry: >-
+          bash -c 'uvx semgrep scan --config semgrep-rules/ --validate &&
+          uvx semgrep --test --config semgrep-rules/ semgrep-rules/'
         language: system
         pass_filenames: false
         files: "semgrep-rules/"

--- a/semgrep-rules/shell-hygiene.sh
+++ b/semgrep-rules/shell-hygiene.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Semgrep test fixture for shell-hygiene.yml (semgrep --test convention:
 # same basename as the rule file; annotated lines assert must-fire vs must-not).
 


### PR DESCRIPTION
Restores the current main branch CI gate after the shell-hygiene fixture landed and removes a host/image formatter version split.

- keep the Semgrep test fixture non-executable
- exclude Semgrep test fixtures from production Semgrep and ShellCheck scans
- align the image Just pin with local and GitHub fast checks at 1.57.0 using upstream-published SHA-256 digests
- use the formatter-compatible Just unstable setting

Validation:
- just check
- uvx semgrep --config semgrep-rules/shell-hygiene.yml --test semgrep-rules/shell-hygiene.sh (2/2 passed)
- local Docker build verified the new Just archive checksum before Docker Desktop exhausted its storage; exact GitHub image build is the remaining oracle