### PR TITLE
fix(action): refresh mutable lint image tags

### DIFF
--- a/docker-action/action.yml
+++ b/docker-action/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Docker image to use"
     required: false
     default: "ghcr.io/alxleo/coding-standards:latest"
+  pull-policy:
+    description: "Docker pull policy (always, missing, or never); defaults to always for the standard latest image"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -30,6 +34,7 @@ runs:
       env:
         CS_IMAGE: ${{ inputs.image }}
         CS_APPLY_FIXES: ${{ inputs.apply-fixes }}
+        CS_PULL_POLICY: ${{ inputs.pull-policy }}
       run: |
         # Use GITHUB_WORKSPACE env var (set by runner) instead of
         # ${{ github.workspace }} (expression context). On Gitea Actions,
@@ -45,8 +50,13 @@ runs:
           env_args=(--env-file "$env_file")
         fi
 
-        # Resolve mutable tags on every invocation while reusing unchanged local layers.
-        docker run --pull=always --rm \
+        pull_policy="${CS_PULL_POLICY:-missing}"
+        if [ -z "${CS_PULL_POLICY}" ] && [ "${CS_IMAGE}" = "ghcr.io/alxleo/coding-standards:latest" ]; then
+          pull_policy=always
+        fi
+
+        # Resolve the standard mutable tag while preserving local-only image overrides.
+        docker run --pull="${pull_policy}" --rm \
           -v "${ws}:/tmp/lint" \
           -e DEFAULT_WORKSPACE=/tmp/lint \
           -e APPLY_FIXES="${CS_APPLY_FIXES}" \

--- a/docker-action/action.yml
+++ b/docker-action/action.yml
@@ -45,7 +45,8 @@ runs:
           env_args=(--env-file "$env_file")
         fi
 
-        docker run --rm \
+        # Resolve mutable tags on every invocation while reusing unchanged local layers.
+        docker run --pull=always --rm \
           -v "${ws}:/tmp/lint" \
           -e DEFAULT_WORKSPACE=/tmp/lint \
           -e APPLY_FIXES="${CS_APPLY_FIXES}" \


### PR DESCRIPTION
## What

- make the reusable Docker action run with `--pull=always`
- retain Docker layer caching while resolving mutable tags before each lint run

## Why

Self-hosted runners can retain an old `ghcr.io/alxleo/coding-standards:latest` image indefinitely. A successful image release therefore did not update consumer CI, and homelab kept running the pre-optimization manifest generator.

## Impact

Every action invocation performs a registry freshness check. Unchanged layers remain cached; changed layers are downloaded before lint starts. Immutable digest inputs continue to work.

## Checks

- `just check`
- `git diff --check`
- downstream cold run pulled digest `sha256:8869ef276cb23e498f449372ad9275f0888b8b418d447328f282e26d438abc31`
- downstream warm registry check completed in about 0.33s
- downstream manifest generation completed in 0.317s

## Downstream proof

- alxleo/homelab#786
- https://github.com/alxleo/homelab/actions/runs/30677876339
