### PR TITLE
ci: update actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           enable-cache: true
 
-      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('lint-configs/.pre-commit-config.yaml') }}
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload MegaLinter report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: megalinter-report
           path: megalinter-reports/


### PR DESCRIPTION
## What

- update `extractions/setup-just` from v2 to v4
- update `actions/cache` from v4 to v6.1.0
- update `actions/upload-artifact` from v4 to v7.0.1
- retain immutable SHA pins

## Why

GitHub was forcing these Node 20-targeting action releases onto Node 24 and annotating every CI run.

## Checks

- focused pre-commit suite for `.github/workflows/ci.yml`
- actionlint
- zizmor
- image-integrity policies
- `git diff --check`
