### PR TITLE
Support centralized consumer linter configs

### DIFF
--- a/.mega-linter-default.yml
+++ b/.mega-linter-default.yml
@@ -138,9 +138,8 @@ DISABLE_ERRORS_LINTERS:
 #
 # Consumer repos override by setting <LINTER>_CONFIG_FILE in their .mega-linter.yml.
 
-# shellcheck: --rcfile points at .mega-linter-config/.shellcheckrc (no root pollution).
-BASH_SHELLCHECK_ARGUMENTS:
-  - "--rcfile=.mega-linter-config/.shellcheckrc"
+# MegaLinter v9.6 passes ShellCheck's config with --rcfile.
+BASH_SHELLCHECK_CONFIG_FILE: .shellcheckrc
 # Semgrep rule fixtures intentionally contain invalid shell snippets.
 BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: "semgrep-rules/.*\\.sh"
 # editorconfig-checker: .editorconfig MUST be at project root per EditorConfig spec.
@@ -167,9 +166,7 @@ PYTHON_VULTURE_ARGUMENTS:
   - "80"
 SPELL_LYCHEE_CONFIG_FILE: .lychee.toml
 PYTHON_RUFF_CONFIG_FILE: ruff.toml
-REPOSITORY_LS_LINT_ARGUMENTS:
-  - "-config"
-  - ".mega-linter-config/.ls-lint.yml"
+REPOSITORY_LS_LINT_CONFIG_FILE: .ls-lint.yml
 API_SPECTRAL_CONFIG_FILE: .spectral.yaml
 JAVASCRIPT_ES_CONFIG_FILE: eslint.config.mjs
 TYPESCRIPT_ES_CONFIG_FILE: eslint.config.mjs
@@ -185,15 +182,9 @@ TYPESCRIPT_PRETTIER_CONFIG_FILE: .prettierrc
 REPOSITORY_GITLEAKS_CONFIG_FILE: .gitleaks.toml
 # editorconfig-checker: _CONFIG_FILE expects an .ecrc (tool config), not .editorconfig.
 # The tool auto-discovers .editorconfig from the workspace root (copied via PRE_COMMANDS).
-SPELL_CODESPELL_ARGUMENTS:
-  - "--config=.mega-linter-config/.codespellrc"
-# v8r: uses cosmiconfig auto-discovery, not CLI flags.
-# YAML_V8R works via _CONFIG_FILE (descriptor has no cli_config_arg_name).
-# JSON_V8R MUST NOT set _CONFIG_FILE — its built-in descriptor injects -c
-# (which means --catalogs, not config). Cosmiconfig finds it via PRE_COMMANDS symlink.
-# v8r: cosmiconfig auto-discovers .v8rrc.yml from cwd. Symlink from
-# .mega-linter-config/ to workspace root so v8r finds it without root pollution.
-# Consumer override: place own .v8rrc.yml at repo root (skips symlink via test -f).
+SPELL_CODESPELL_CONFIG_FILE: .codespellrc
+# MegaLinter v9.5+ passes v8r config through V8R_CONFIG_FILE for both descriptors.
+JSON_V8R_CONFIG_FILE: .v8rrc.yml
 YAML_V8R_CONFIG_FILE: .v8rrc.yml
 
 # Kubeconform: --strict rejects unknown fields (catches typos in manifests)
@@ -298,22 +289,13 @@ PRE_COMMANDS:
       python3 /opt/coding-standards/scripts/generate_repo_manifest.py
     cwd: workspace
     continue_if_failed: true
-  # Copy baked configs to .mega-linter-config/ — keeps consumer workspace clean.
-  # Consumer overrides: place own config file (checked via test ! -f).
-  # Exceptions: .editorconfig at root (EditorConfig spec), .v8rrc.yml symlinked
-  # to root (cosmiconfig only searches project root).
+  # EditorConfig and v8r's ignore file are discovery files, not CLI configs.
+  # Keep the remaining compatibility copies guarded so consumer files win.
   - command: >-
-      mkdir -p .mega-linter-config &&
-      for f in .shellcheckrc .codespellrc .ls-lint.yml .v8rrc.yml; do
-        test ! -f ".mega-linter-config/$f" &&
-          cp "/opt/coding-standards/configs/$f" ".mega-linter-config/$f" 2>/dev/null || true;
-      done &&
       test ! -f .editorconfig &&
         cp /opt/coding-standards/configs/.editorconfig .editorconfig 2>/dev/null || true &&
       test ! -f .v8rignore &&
-        cp /opt/coding-standards/configs/.v8rignore .v8rignore 2>/dev/null || true &&
-      test ! -f .v8rrc.yml && test -f .mega-linter-config/.v8rrc.yml &&
-        ln -sf .mega-linter-config/.v8rrc.yml .v8rrc.yml 2>/dev/null || true
+        cp /opt/coding-standards/configs/.v8rignore .v8rignore 2>/dev/null || true
     cwd: workspace
     continue_if_failed: true
   # Install JS deps if package-lock.json exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,10 @@ Touch these files — the integrity hook validates completeness:
 
 ## Key constraints
 
-- **`_CONFIG_FILE` must be bare filenames** — `ruff.toml` not `/opt/.../ruff.toml`. MegaLinter concatenates `LINTER_RULES_PATH + _CONFIG_FILE`. Enforced by `check-megalinter-config-paths`.
+- **Baked `_CONFIG_FILE` values must be bare filenames** — `ruff.toml` not `/opt/.../ruff.toml`. The entrypoint qualifies matching consumer files from `LINTER_RULES_PATH`; absolute baked paths break MegaLinter resolution. Enforced by `check-megalinter-config-paths`.
 - **Binary checksums: both architectures** — every `curl` download needs `_SHA256_amd64` and `_SHA256_arm64`. PMD is exempt (Java, arch-agnostic). Enforced by integrity hook.
 - **Semgrep rule IDs: `coding-standards.` prefix** — ensures predictable `--exclude-rule` for consumers.
-- **No workspace root pollution** — baked configs go to `.mega-linter-config/` via PRE_COMMANDS. Exceptions: `.editorconfig` (spec requires root), `.v8rrc.yml` (symlink for cosmiconfig).
+- **No workspace root pollution** — consumers keep linter configs in the directory named by `LINTER_RULES_PATH`. `.editorconfig` is the deliberate root exception because the EditorConfig specification requires directory-tree discovery.
 - **No runtime network calls** — the image is offline-first. Schemas, semgrep rules, trivy DB baked at build time. Tools that need network (zizmor pin verification) run with `--offline` in CI; online checks go in scheduled workflows. Token passthrough (env-file, git credential store) exists for opt-in online use.
 - **Consumer files are read-only** — never `sed -i` or modify mounted workspace files. Use temp copies.
 

--- a/docs/config-decisions.md
+++ b/docs/config-decisions.md
@@ -130,9 +130,10 @@ Decisions made 2026-03-29. Revisit if assumptions change.
 - Image ships .mega-linter.yml + linter configs. Works offline.
 - The baked `LINTER_RULES_PATH` points inside the image
   (`/opt/coding-standards/configs`).
-- A consumer sets `LINTER_RULES_PATH: quality/lint` once. The entrypoint expands
-  matching files to relative per-linter `_RULES_PATH` values, preserving baked
-  fallbacks and avoiding MegaLinter v9.6's absolute-path activation bug.
+- A consumer sets `LINTER_RULES_PATH: quality/lint` once. The entrypoint selects
+  matching files with explicit workspace-relative `_CONFIG_FILE` values,
+  preserving baked fallbacks while avoiding MegaLinter v9.6's root-first search
+  order and absolute-path activation bug.
 - No EXTENDS / CONFIG_PROPERTIES_TO_APPEND by default. Replace > merge (simpler).
 
 ### Reporters

--- a/docs/config-decisions.md
+++ b/docs/config-decisions.md
@@ -117,18 +117,22 @@ Decisions made 2026-03-29. Revisit if assumptions change.
 
 - Most linters: `_CONFIG_FILE` pointing to baked config. MegaLinter auto-passes it via `cli_config_arg_name`.
 - Consumer repos override via `<LINTER>_CONFIG_FILE: myconfig.toml` — one line, works correctly.
-- Exceptions (tools where `_CONFIG_FILE` injects the wrong flag):
-  - **JSON v8r**: built-in descriptor's `-c` means `--catalogs`, not config. Config copied to workspace via PRE_COMMANDS; cosmiconfig discovers it.
-  - **shellcheck**: built-in descriptor inherits default `-c` which shellcheck has never accepted (uses `--rcfile` since v0.10, auto-discovery since v0.7). Config copied to workspace via PRE_COMMANDS.
+- MegaLinter v9.6 correctly wires ShellCheck through `--rcfile` and both v8r
+  descriptors through `V8R_CONFIG_FILE`; they now use `_CONFIG_FILE` like the
+  other linters.
+- Remaining discovery exceptions:
   - **shfmt**: reads `.editorconfig` from file's directory tree. Symlinked at repo root, copied to workspace via PRE_COMMANDS.
   - **editorconfig-checker**: built-in `-config` expects `.ecrc` (tool JSON config), not `.editorconfig`. Auto-discovers `.editorconfig` from workspace.
-- PRE_COMMANDS copies use `test ! -f` guards — consumer files at workspace root take precedence over baked defaults.
+- PRE_COMMANDS copies use `test ! -f` guards for the remaining discovery files.
 
 ### Config distribution: baked + override
 
 - Image ships .mega-linter.yml + linter configs. Works offline.
-- Consumer repos override via own .mega-linter.yml or per-linter _CONFIG_FILE.
-- LINTER_RULES_PATH points inside image (/opt/coding-standards/configs).
+- The baked `LINTER_RULES_PATH` points inside the image
+  (`/opt/coding-standards/configs`).
+- A consumer sets `LINTER_RULES_PATH: quality/lint` once. The entrypoint expands
+  matching files to relative per-linter `_RULES_PATH` values, preserving baked
+  fallbacks and avoiding MegaLinter v9.6's absolute-path activation bug.
 - No EXTENDS / CONFIG_PROPERTIES_TO_APPEND by default. Replace > merge (simpler).
 
 ### Reporters
@@ -152,7 +156,10 @@ Decisions made 2026-03-29. Revisit if assumptions change.
 ### PRE_COMMANDS
 
 - git safe.directory + autocrlf fix (Docker UID mismatch).
-- Copy baked configs to workspace root for tools that auto-discover (v8r, shellcheck, shfmt, editorconfig-checker, codespell, ls-lint). Uses `cp` not symlinks (prettier rejects symlinks). NOTE: MegaLinter checks `active_only_if_file_found` BEFORE PRE_COMMANDS, so these copies provide config, not activation. commitlint excluded — needs git history (HEAD~1) which Docker-mounted workspaces lack.
+- Copy only `.editorconfig` and `.v8rignore` to the workspace for their native
+  discovery protocols. CLI-addressable configs use `_CONFIG_FILE` and the rules
+  directory instead. commitlint remains excluded because it needs git history
+  (`HEAD~1`) that Docker-mounted workspaces may lack.
 - npm ci guard (runs only if package-lock.json exists).
 
 ### Self-lint: MEGALINTER_CONFIG override

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -34,8 +34,8 @@ ENABLE_LINTERS:
   - YAML_YAMLLINT
   # ... add what your repo needs
 
-# Use your repo's own linter config
-PYTHON_RUFF_CONFIG_FILE: ruff.toml
+# Keep all repository-owned linter configs out of the root.
+LINTER_RULES_PATH: quality/lint
 ```
 
 Without a `.mega-linter.yml`, the image runs with its baked defaults (all 55 linters, baseline configs).
@@ -63,12 +63,23 @@ DISABLE_LINTERS:
   - TERRAFORM_TFLINT      # no terraform here
   - REPOSITORY_KNIP       # no JS/TS
 
-# Use your repo's own linter config — just set _CONFIG_FILE.
-# MegaLinter passes it via the appropriate mechanism (CLI flag or native discovery).
-ANSIBLE_ANSIBLE_LINT_CONFIG_FILE: .ansible-lint
-PYTHON_RUFF_CONFIG_FILE: ruff.toml
-REPOSITORY_GITLEAKS_CONFIG_FILE: .gitleaks.toml
+# Canonical directory for every repository-owned linter config.
+# Config filenames that match the baseline need no per-linter entries.
+LINTER_RULES_PATH: quality/lint
+
+# Only declare a filename when it differs from the baseline default.
+ACTION_ACTIONLINT_CONFIG_FILE: actionlint.yaml
 ```
+
+With the coding-standards image, a workspace-relative `LINTER_RULES_PATH` is an
+overlay: matching files in that directory win, while missing files continue to
+use the configs baked into the image. Keep only `.mega-linter.yml` at the repo
+root and place linter-owned files such as `ruff.toml`, `.yamllint`,
+`.shellcheckrc`, and `.gitleaks.toml` in `quality/lint/`.
+
+`.editorconfig` is the deliberate exception. It is a repository-wide editor
+standard whose discovery protocol requires it in the directory tree, not a
+MegaLinter-only config file.
 
 ### Suppress specific semgrep rules
 
@@ -219,13 +230,14 @@ POST_COMMANDS:
     continue_if_failed: false
 ```
 
-### 5. Per-linter config overrides
+### 5. Linter config directory and filename overrides
 
-Override any linter's config by setting `<LINTER>_CONFIG_FILE` in your `.mega-linter.yml`:
+Set the shared directory once. Override `<LINTER>_CONFIG_FILE` only when a file
+uses a non-default name:
 
 ```yaml
-YAML_YAMLLINT_CONFIG_FILE: .yamllint
-PYTHON_RUFF_CONFIG_FILE: ruff.toml
+LINTER_RULES_PATH: quality/lint
+ACTION_ACTIONLINT_CONFIG_FILE: actionlint.yaml
 ```
 
 ## Migrating to new rules

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -260,17 +260,15 @@ For shellcheck findings (e.g., `require-double-brackets`):
 
 ## Gitignore
 
-The image creates temporary config and cache files during lint runs. Add to `.gitignore`:
+The image creates reports and cache files during lint runs. Add to `.gitignore`:
 
 ```gitignore
 # coding-standards lint artifacts
-.mega-linter-config/    # baked linter configs (shellcheckrc, codespellrc, etc.)
 megalinter-reports/     # lint output
 repo-manifest.json      # generated for repo-standards checks
 .lycheecache            # lychee link checker cache
 .ruff_cache/            # ruff lint cache
 .editorconfig           # only if you don't have your own
-.v8rrc.yml              # symlink to .mega-linter-config/
 ```
 
 If your repo already has an `.editorconfig`, it won't be overwritten — the image only creates one if missing.

--- a/docs/help/gitignore.md
+++ b/docs/help/gitignore.md
@@ -2,13 +2,11 @@
 
 ```gitignore
 # coding-standards lint artifacts
-.mega-linter-config/
 megalinter-reports/
 repo-manifest.json
 .lycheecache
 .ruff_cache/
 .editorconfig           # only if you don't have your own
-.v8rrc.yml              # symlink to .mega-linter-config/
 ```
 
 Run `just cs-init` to add these automatically.

--- a/docs/help/override.md
+++ b/docs/help/override.md
@@ -1,15 +1,16 @@
 # Overriding any linter's config
 
-Set `<LINTER>_CONFIG_FILE` in your `.mega-linter.yml`:
+Put repository-owned configs in one directory and set it once:
 
 ```yaml
-PYTHON_RUFF_CONFIG_FILE: ruff.toml
-YAML_YAMLLINT_CONFIG_FILE: .yamllint
-REPOSITORY_GITLEAKS_CONFIG_FILE: .gitleaks.toml
-ANSIBLE_ANSIBLE_LINT_CONFIG_FILE: .ansible-lint
-PYTHON_PYRIGHT_CONFIG_FILE: pyrightconfig.json
+LINTER_RULES_PATH: quality/lint
 ```
 
-Your file takes precedence over the baked config.
+Matching files take precedence over baked configs. If a filename differs from
+the baseline default, declare only that override:
+
+```yaml
+ACTION_ACTIONLINT_CONFIG_FILE: actionlint.yaml
+```
 
 Run `just cs-show-config` to see what each linter uses.

--- a/docs/help/ruff.md
+++ b/docs/help/ruff.md
@@ -1,25 +1,22 @@
 # Overriding Python (ruff) config
 
-## Extend the baseline
+## Repository config
 
 ```toml
-# ruff.toml
-extend = ".mega-linter-config/ruff.toml"
+# quality/lint/ruff.toml
 [lint]
 select = ["ALL"]
 ```
 
-## Full replacement
-
-```toml
-# ruff.toml — your own, no extend
-```
-
-Set in `.mega-linter.yml`:
+Select the shared config directory in `.mega-linter.yml`:
 
 ```yaml
-PYTHON_RUFF_CONFIG_FILE: ruff.toml
+LINTER_RULES_PATH: quality/lint
 ```
+
+The filename already matches the baseline default, so no Ruff-specific
+MegaLinter setting is required. This repository config replaces the baked Ruff
+baseline.
 
 ## Migration recipe
 

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -43,7 +43,9 @@ def _local_rules_directory(rules_path: str, workspace: Path) -> Path:
     raise ValueError(message)
 
 
-def _assign_matching_rules_paths(merged: dict[str, object], rules_path: str, rules_directory: Path) -> None:
+def _select_matching_consumer_configs(
+    merged: dict[str, object], overrides: dict[str, object], rules_path: str, rules_directory: Path
+) -> None:
     for key, value in tuple(merged.items()):
         if not (key.endswith("_CONFIG_FILE") and isinstance(value, str)):
             continue
@@ -52,7 +54,11 @@ def _assign_matching_rules_paths(merged: dict[str, object], rules_path: str, rul
             continue
         if (rules_directory / config_path).is_file():
             rules_key = f"{key.removesuffix('_CONFIG_FILE')}_RULES_PATH"
-            merged.setdefault(rules_key, rules_path)
+            if rules_key not in overrides:
+                # MegaLinter searches the workspace root before RULES_PATH. Use
+                # the explicit workspace-relative filename so the canonical
+                # directory wins even during a migration with stale root files.
+                merged[key] = str(Path(rules_path) / config_path)
 
 
 def _warn_for_missing_overrides(overrides: dict[str, object], workspace: Path, rules_directory: Path) -> None:
@@ -70,10 +76,10 @@ def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[s
     """Overlay a consumer LINTER_RULES_PATH without hiding baked configs.
 
     MegaLinter treats LINTER_RULES_PATH as a replacement.  The coding-standards
-    image instead keeps its baked directory as the fallback and assigns the
-    consumer directory to each linter whose config exists there.  Per-linter
-    paths also avoid MegaLinter v9.6's activation bug with an absolute global
-    rules path.
+    image instead keeps its baked directory as the fallback and selects each
+    matching consumer config by its explicit workspace-relative path. This also
+    avoids MegaLinter v9.6's root-first search order and absolute-path
+    activation bug.
     """
     rules_path = overrides.pop("LINTER_RULES_PATH", None)
     if rules_path is None:
@@ -86,7 +92,7 @@ def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[s
         return
 
     rules_directory = _local_rules_directory(rules_path, workspace)
-    _assign_matching_rules_paths(merged, rules_path, rules_directory)
+    _select_matching_consumer_configs(merged, overrides, rules_path, rules_directory)
     _warn_for_missing_overrides(overrides, workspace, rules_directory)
 
 
@@ -245,7 +251,13 @@ def show_config() -> None:
     """Show which config file each linter uses + local overrides."""
     os.chdir(_workspace())
     subprocess.run(
-        ["python3", str(SCRIPTS / "show_config.py"), ".", "--mega-linter-yml", str(BAKED_CONFIG)],
+        [
+            "python3",
+            str(SCRIPTS / "show_config.py"),
+            ".",
+            "--mega-linter-yml",
+            os.environ.get("MEGALINTER_CONFIG", str(BAKED_CONFIG)),
+        ],
         check=True,
     )
 

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -35,19 +35,59 @@ def _workspace() -> Path:
     return Path(os.environ.get("DEFAULT_WORKSPACE", "/tmp/lint"))
 
 
-def _resolve_config_overrides(overrides: dict[str, object], workspace: Path) -> None:
-    """Rewrite _CONFIG_FILE overrides to workspace-absolute paths."""
-    workspace_resolved = workspace.resolve()
+def _local_rules_directory(rules_path: str, workspace: Path) -> Path:
+    rules_directory = (workspace / rules_path).resolve()
+    if rules_directory.is_relative_to(workspace.resolve()) and rules_directory.is_dir():
+        return rules_directory
+    message = f"LINTER_RULES_PATH should be a workspace directory ({rules_path})"
+    raise ValueError(message)
+
+
+def _assign_matching_rules_paths(merged: dict[str, object], rules_path: str, rules_directory: Path) -> None:
+    for key, value in tuple(merged.items()):
+        if not (key.endswith("_CONFIG_FILE") and isinstance(value, str)):
+            continue
+        config_path = Path(value)
+        if config_path.is_absolute() or len(config_path.parts) != 1:
+            continue
+        if (rules_directory / config_path).is_file():
+            rules_key = f"{key.removesuffix('_CONFIG_FILE')}_RULES_PATH"
+            merged.setdefault(rules_key, rules_path)
+
+
+def _warn_for_missing_overrides(overrides: dict[str, object], workspace: Path, rules_directory: Path) -> None:
     for key, value in overrides.items():
-        if not (key.endswith("_CONFIG_FILE") and isinstance(value, str) and not Path(value).is_absolute()):
+        if not (key.endswith("_CONFIG_FILE") and isinstance(value, str)):
             continue
-        candidate = (workspace / value).resolve()
-        if not candidate.is_relative_to(workspace_resolved):
+        config_path = Path(value)
+        if config_path.is_absolute():
             continue
-        if candidate.is_file():
-            overrides[key] = str(candidate)
-        else:
-            typer.echo(f"Warning: {key} override points to missing file: {candidate}", err=True)
+        if not (workspace / config_path).is_file() and not (rules_directory / config_path).is_file():
+            typer.echo(f"Warning: {key} override points to missing file: {value}", err=True)
+
+
+def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[str, object], workspace: Path) -> None:
+    """Overlay a consumer LINTER_RULES_PATH without hiding baked configs.
+
+    MegaLinter treats LINTER_RULES_PATH as a replacement.  The coding-standards
+    image instead keeps its baked directory as the fallback and assigns the
+    consumer directory to each linter whose config exists there.  Per-linter
+    paths also avoid MegaLinter v9.6's activation bug with an absolute global
+    rules path.
+    """
+    rules_path = overrides.pop("LINTER_RULES_PATH", None)
+    if rules_path is None:
+        return
+    if not isinstance(rules_path, str) or not rules_path.strip():
+        message = "LINTER_RULES_PATH must be a non-empty directory path"
+        raise ValueError(message)
+    if rules_path.startswith("http") or Path(rules_path).is_absolute():
+        merged["LINTER_RULES_PATH"] = rules_path
+        return
+
+    rules_directory = _local_rules_directory(rules_path, workspace)
+    _assign_matching_rules_paths(merged, rules_path, rules_directory)
+    _warn_for_missing_overrides(overrides, workspace, rules_directory)
 
 
 def _setup() -> None:
@@ -99,8 +139,11 @@ def _setup() -> None:
         baked = yaml.safe_load(BAKED_CONFIG.read_text())
         overrides = yaml.safe_load(content) if content.strip() else {}
         if overrides:
-            _resolve_config_overrides(overrides, workspace)
+            consumer_rules_path = overrides.pop("LINTER_RULES_PATH", None)
             baked.update(overrides)
+            if consumer_rules_path is not None:
+                overrides["LINTER_RULES_PATH"] = consumer_rules_path
+            _apply_consumer_rules_directory(baked, overrides, workspace)
         with tempfile.NamedTemporaryFile(suffix=".yml", prefix="mega-linter-merged-", delete=False, mode="w") as f:
             yaml.dump(baked, f, default_flow_style=False)
             os.environ["MEGALINTER_CONFIG"] = f.name

--- a/scripts/hooks/check-megalinter-config-paths
+++ b/scripts/hooks/check-megalinter-config-paths
@@ -4,7 +4,8 @@
 MegaLinter resolves _CONFIG_FILE by concatenating workspace + "/" + value.
 Absolute paths like /opt/coding-standards/configs/ruff.toml produce
 /tmp/lint//opt/coding-standards/configs/ruff.toml — which doesn't exist.
-Every _CONFIG_FILE must be a bare filename (resolved via LINTER_RULES_PATH).
+Every baked _CONFIG_FILE must be a bare filename. The entrypoint qualifies
+matching consumer files from their workspace-relative LINTER_RULES_PATH.
 """
 
 import sys

--- a/scripts/recommend.py
+++ b/scripts/recommend.py
@@ -213,8 +213,8 @@ if has_files(["*.py"]) and not file_exists("ruff.toml"):
             "reason": "Python files detected but no ruff.toml — using baked defaults",
             "value": "Custom rule selection, per-file ignores, line length. Extend the baseline or replace it.",
             "setup": [
-                "# Extend baked config:",
-                "# echo 'extend = \".mega-linter-config/ruff.toml\"' > ruff.toml",
+                "# Add a repository config at quality/lint/ruff.toml",
+                "# and set LINTER_RULES_PATH: quality/lint in .mega-linter.yml",
                 "# Or see: just cs-help ruff",
             ],
         }
@@ -258,8 +258,8 @@ if has_files(["*.yml", "*.yaml"]) and not file_exists(".yamllint"):
             "reason": "YAML files detected but no .yamllint — using baked defaults",
             "value": "Custom line length, truthy values, comment indentation rules",
             "setup": [
-                "# Create .yamllint to override specific rules",
-                "# See baked config: .mega-linter-config/.yamllint",
+                "# Create quality/lint/.yamllint to override specific rules",
+                "# Set LINTER_RULES_PATH: quality/lint in .mega-linter.yml",
             ],
         }
     )

--- a/scripts/show_config.py
+++ b/scripts/show_config.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Show which config file each linter uses and whether a workspace override shadows it.
+"""Show which config file each linter uses and whether the workspace overrides it.
 
-Reads .mega-linter-default.yml for _CONFIG_FILE entries, resolves the baked-in
-config path, and checks if the workspace root contains a local file that would
-shadow (override) the baked config.
+Reads the effective MegaLinter YAML for _CONFIG_FILE entries and identifies
+workspace-root or canonical rules-directory overrides.
 
 Usage:
     show_config.py [workspace] [--mega-linter-yml PATH]
@@ -105,7 +104,11 @@ def show_config(workspace: Path, yml_path: Path) -> list[dict[str, str]]:
     rows = []
     for entry in entries:
         linter = entry["linter"]
-        shadows = _find_shadows(workspace, entry["config_basename"])
+        selected_path = Path(entry["config_path"])
+        if len(selected_path.parts) > 1 and not selected_path.is_absolute() and (workspace / selected_path).is_file():
+            shadows = [entry["config_path"]]
+        else:
+            shadows = _find_shadows(workspace, entry["config_basename"])
         tier = "warn" if linter in warn_linters else "error"
         rows.append(
             {

--- a/templates/gitignore-entries
+++ b/templates/gitignore-entries
@@ -1,7 +1,5 @@
 # coding-standards lint artifacts
-.mega-linter-config/
 megalinter-reports/
 repo-manifest.json
 .lycheecache
 .ruff_cache/
-.v8rrc.yml

--- a/test/test_entrypoint_config.py
+++ b/test/test_entrypoint_config.py
@@ -1,4 +1,4 @@
-"""Tests for entrypoint.py _CONFIG_FILE path resolution logic."""
+"""Tests for entrypoint.py consumer rules-directory resolution."""
 
 from __future__ import annotations
 
@@ -15,7 +15,15 @@ def workspace(tmp_path):
     """Create a temp workspace with a baked config and consumer .mega-linter.yml."""
     # Baked config (minimal)
     baked = tmp_path / "baked.yml"
-    baked.write_text(yaml.dump({"ENABLE_LINTERS": "PYTHON_RUFF"}))
+    baked.write_text(
+        yaml.dump(
+            {
+                "ENABLE_LINTERS": "PYTHON_RUFF",
+                "LINTER_RULES_PATH": "/opt/coding-standards/configs",
+                "PYTHON_RUFF_CONFIG_FILE": "ruff.toml",
+            }
+        )
+    )
 
     # Patch constants
     with patch("scripts.entrypoint.BAKED_CONFIG", baked), patch("scripts.entrypoint._workspace", return_value=tmp_path):
@@ -43,55 +51,83 @@ def _read_merged_config() -> dict:
     return yaml.safe_load(Path(config_path).read_text())
 
 
-class TestConfigFileResolution:
-    def test_relative_config_rewritten_to_absolute(self, workspace):
-        """Consumer ruff.toml override is rewritten to workspace-absolute path."""
-        (workspace / "ruff.toml").write_text("[lint]\nselect = ['E']\n")
-        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "ruff.toml"})
+class TestRulesDirectoryResolution:
+    def test_rules_directory_applies_to_matching_linter(self, workspace):
+        """A single rules directory selects a matching consumer config."""
+        rules = workspace / "quality" / "lint"
+        rules.mkdir(parents=True)
+        (rules / "ruff.toml").write_text("[lint]\nselect = ['E']\n")
+        (rules / "actionlint.yaml").write_text("self-hosted-runner: {}\n")
+        _write_consumer_config(
+            workspace,
+            {
+                "LINTER_RULES_PATH": "quality/lint",
+                "ACTION_ACTIONLINT_CONFIG_FILE": "actionlint.yaml",
+            },
+        )
 
         _run_setup()
 
         merged = _read_merged_config()
-        expected = str((workspace / "ruff.toml").resolve())
-        assert merged["PYTHON_RUFF_CONFIG_FILE"] == expected
+        assert merged["PYTHON_RUFF_RULES_PATH"] == "quality/lint"
+        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "ruff.toml"
+        assert merged["ACTION_ACTIONLINT_RULES_PATH"] == "quality/lint"
+        assert merged["ACTION_ACTIONLINT_CONFIG_FILE"] == "actionlint.yaml"
 
-    def test_path_traversal_rejected(self, workspace):
-        """../../etc/passwd traversal is blocked by is_relative_to check."""
-        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "../../etc/passwd"})
+    def test_rules_directory_preserves_baked_fallback(self, workspace):
+        """Linters without a consumer config retain the baked rules path."""
+        baked = workspace / "baked.yml"
+        baked.write_text(
+            yaml.dump(
+                {
+                    "LINTER_RULES_PATH": "/opt/coding-standards/configs",
+                    "PYTHON_RUFF_CONFIG_FILE": "ruff.toml",
+                }
+            )
+        )
+        rules = workspace / "quality" / "lint"
+        rules.mkdir(parents=True)
+        _write_consumer_config(workspace, {"LINTER_RULES_PATH": "quality/lint"})
 
         _run_setup()
 
         merged = _read_merged_config()
-        # Should NOT be rewritten — the original relative path stays as-is
-        assert merged.get("PYTHON_RUFF_CONFIG_FILE") == "../../etc/passwd"
+        assert merged["LINTER_RULES_PATH"] == "/opt/coding-standards/configs"
+        assert "PYTHON_RUFF_RULES_PATH" not in merged
 
-    def test_missing_file_produces_warning(self, workspace, capsys):
+    def test_explicit_missing_file_produces_warning(self, workspace, capsys):
         """Missing file within workspace produces a stderr warning."""
-        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "nonexistent.toml"})
+        rules = workspace / "quality" / "lint"
+        rules.mkdir(parents=True)
+        _write_consumer_config(
+            workspace,
+            {"LINTER_RULES_PATH": "quality/lint", "PYTHON_RUFF_CONFIG_FILE": "nonexistent.toml"},
+        )
 
         _run_setup()
 
         merged = _read_merged_config()
-        # Not rewritten since file doesn't exist
-        assert merged.get("PYTHON_RUFF_CONFIG_FILE") != str(workspace / "nonexistent.toml")
+        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "nonexistent.toml"
 
         captured = capsys.readouterr()
         assert "Warning: PYTHON_RUFF_CONFIG_FILE override points to missing file" in captured.err
 
-    def test_absolute_path_not_modified(self, workspace):
-        """Absolute paths are left as-is (consumer knows what they're doing)."""
-        _write_consumer_config(workspace, {"PYTHON_RUFF_CONFIG_FILE": "/opt/custom/ruff.toml"})
+    def test_invalid_rules_directory_rejected(self, workspace):
+        _write_consumer_config(workspace, {"LINTER_RULES_PATH": "../../outside"})
+
+        with pytest.raises(ValueError, match="workspace directory"):
+            _run_setup()
+
+    def test_explicit_per_linter_rules_path_wins(self, workspace):
+        rules = workspace / "quality" / "lint"
+        rules.mkdir(parents=True)
+        (rules / "ruff.toml").write_text("[lint]\n")
+        _write_consumer_config(
+            workspace,
+            {"LINTER_RULES_PATH": "quality/lint", "PYTHON_RUFF_RULES_PATH": "custom/ruff"},
+        )
 
         _run_setup()
 
         merged = _read_merged_config()
-        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "/opt/custom/ruff.toml"
-
-    def test_non_config_file_keys_not_modified(self, workspace):
-        """Keys that don't end in _CONFIG_FILE are left alone."""
-        _write_consumer_config(workspace, {"PYTHON_RUFF_ARGUMENTS": ["--fix"]})
-
-        _run_setup()
-
-        merged = _read_merged_config()
-        assert merged["PYTHON_RUFF_ARGUMENTS"] == ["--fix"]
+        assert merged["PYTHON_RUFF_RULES_PATH"] == "custom/ruff"

--- a/test/test_entrypoint_config.py
+++ b/test/test_entrypoint_config.py
@@ -69,10 +69,10 @@ class TestRulesDirectoryResolution:
         _run_setup()
 
         merged = _read_merged_config()
-        assert merged["PYTHON_RUFF_RULES_PATH"] == "quality/lint"
-        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "ruff.toml"
-        assert merged["ACTION_ACTIONLINT_RULES_PATH"] == "quality/lint"
-        assert merged["ACTION_ACTIONLINT_CONFIG_FILE"] == "actionlint.yaml"
+        assert "PYTHON_RUFF_RULES_PATH" not in merged
+        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "quality/lint/ruff.toml"
+        assert "ACTION_ACTIONLINT_RULES_PATH" not in merged
+        assert merged["ACTION_ACTIONLINT_CONFIG_FILE"] == "quality/lint/actionlint.yaml"
 
     def test_rules_directory_preserves_baked_fallback(self, workspace):
         """Linters without a consumer config retain the baked rules path."""
@@ -131,3 +131,4 @@ class TestRulesDirectoryResolution:
 
         merged = _read_merged_config()
         assert merged["PYTHON_RUFF_RULES_PATH"] == "custom/ruff"
+        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "ruff.toml"

--- a/test/test_show_config.py
+++ b/test/test_show_config.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 # Import via spec loader (script lives in scripts/, not a package)
 _script = Path(__file__).resolve().parent.parent / "scripts" / "show_config.py"
@@ -118,6 +119,19 @@ class TestShowConfig:
         rows = show_config(workspace_with_ruff, sample_yml)
         ruff_row = next(r for r in rows if r["linter"] == "PYTHON_RUFF")
         assert "ruff.toml" in ruff_row["shadow"]
+
+    def test_detects_selected_rules_directory_config(self, empty_workspace: Path, sample_yml: Path) -> None:
+        rules = empty_workspace / "quality" / "lint"
+        rules.mkdir(parents=True)
+        (rules / "ruff.toml").write_text("[lint]\n")
+        data = yaml.safe_load(sample_yml.read_text())
+        data["PYTHON_RUFF_CONFIG_FILE"] = "quality/lint/ruff.toml"
+        sample_yml.write_text(yaml.safe_dump(data))
+
+        rows = show_config(empty_workspace, sample_yml)
+
+        ruff_row = next(r for r in rows if r["linter"] == "PYTHON_RUFF")
+        assert ruff_row["shadow"] == "quality/lint/ruff.toml"
 
     def test_tier_classification(self, empty_workspace: Path, sample_yml: Path) -> None:
         rows = show_config(empty_workspace, sample_yml)


### PR DESCRIPTION
## Summary
- treat a workspace-relative `LINTER_RULES_PATH` as a consumer overlay while retaining baked fallbacks
- map matching configs to per-linter rules paths to avoid MegaLinter v9.6 absolute-path activation failures
- use native v9.6 config wiring for ShellCheck, ls-lint, codespell, and both v8r descriptors
- document `quality/lint` as the canonical downstream config directory

## Validation
- `just check`
- branch image built successfully with MegaLinter v9.6.0
- image MegaLinter run proved native ShellCheck, ls-lint, codespell, JSON v8r, and YAML v8r config wiring; the full self-lint still reports existing pyright and first-run Trivy DB failures unrelated to this diff
