### PR TITLE
fix: support centralized Trivy configuration

### DIFF
--- a/.mega-linter-default.yml
+++ b/.mega-linter-default.yml
@@ -147,6 +147,7 @@ BASH_SHELLCHECK_FILTER_REGEX_EXCLUDE: "semgrep-rules/.*\\.sh"
 # rumdl: custom plugin with cli_config_arg_name: --config. Clean _CONFIG_FILE.
 MARKDOWN_RUMDL_CONFIG_FILE: .markdownlint-cli2.yaml
 REPOSITORY_COMMITLINT_CONFIG_FILE: commitlint.config.mjs
+REPOSITORY_TRIVY_CUSTOM_CONFIG_FILE: trivy.yaml
 REPOSITORY_ZIZMOR_CONFIG_FILE: .zizmor.yml
 # Offline mode: no network calls at lint time. Pin verification runs in
 # scheduled workflows (with token). Static checks (injection, permissions,

--- a/lint-configs/trivy.yaml
+++ b/lint-configs/trivy.yaml
@@ -1,0 +1,3 @@
+# Neutral fallback configuration. Consumers can replace this from their
+# LINTER_RULES_PATH without keeping trivy.yaml in the workspace root.
+scan: {}

--- a/plugins/trivy.megalinter-descriptor.yml
+++ b/plugins/trivy.megalinter-descriptor.yml
@@ -19,7 +19,9 @@ linters:
       - "1"
       - --quiet
       - .
+    cli_config_arg_name: "--config"
     cli_help_arg_name: --help
     cli_version_arg_name: --version
+    config_file_name: trivy.yaml
     files_sub_directory: ""
     file_extensions: []

--- a/test/test_entrypoint_config.py
+++ b/test/test_entrypoint_config.py
@@ -21,6 +21,7 @@ def workspace(tmp_path):
                 "ENABLE_LINTERS": "PYTHON_RUFF",
                 "LINTER_RULES_PATH": "/opt/coding-standards/configs",
                 "PYTHON_RUFF_CONFIG_FILE": "ruff.toml",
+                "REPOSITORY_TRIVY_CUSTOM_CONFIG_FILE": "trivy.yaml",
             }
         )
     )
@@ -58,6 +59,7 @@ class TestRulesDirectoryResolution:
         rules.mkdir(parents=True)
         (rules / "ruff.toml").write_text("[lint]\nselect = ['E']\n")
         (rules / "actionlint.yaml").write_text("self-hosted-runner: {}\n")
+        (rules / "trivy.yaml").write_text("scan:\n  skip-dirs: [.decrypted]\n")
         _write_consumer_config(
             workspace,
             {
@@ -73,6 +75,7 @@ class TestRulesDirectoryResolution:
         assert merged["PYTHON_RUFF_CONFIG_FILE"] == "quality/lint/ruff.toml"
         assert "ACTION_ACTIONLINT_RULES_PATH" not in merged
         assert merged["ACTION_ACTIONLINT_CONFIG_FILE"] == "quality/lint/actionlint.yaml"
+        assert merged["REPOSITORY_TRIVY_CUSTOM_CONFIG_FILE"] == "quality/lint/trivy.yaml"
 
     def test_rules_directory_preserves_baked_fallback(self, workspace):
         """Linters without a consumer config retain the baked rules path."""


### PR DESCRIPTION
## Summary
- make the custom Trivy plugin accept an explicit config file
- select `trivy.yaml` from a consumer `LINTER_RULES_PATH`
- retain a neutral baked fallback when consumers do not override it

## Verification
- `uv run pytest -q test/test_entrypoint_config.py`
- `just check`
- `just build`
- local Homelab container run showed `trivy ... --config /tmp/lint/quality/lint/trivy.yaml`

Follow-up to #135, found by the Homelab exact-head consumer oracle.