### PR TITLE
fix: pass compose files directly to dclint

### DIFF
--- a/plugins/dclint.megalinter-descriptor.yml
+++ b/plugins/dclint.megalinter-descriptor.yml
@@ -5,13 +5,11 @@ linters:
     name: DOCKERFILE_DCLINT
     descriptor_flavors:
       - cupcake
-    cli_lint_mode: project
+    cli_lint_mode: list_of_files
     linter_text: Lint Docker Compose files
     linter_url: https://github.com/zavoloklom/docker-compose-linter
     cli_executable: dclint
-    cli_lint_extra_args:
-      - lint
-      - .
+    cli_lint_extra_args: []
     cli_help_arg_name: --help
     cli_version_arg_name: --version
     file_extensions: []

--- a/test/test_plugin_descriptors.py
+++ b/test/test_plugin_descriptors.py
@@ -1,0 +1,13 @@
+"""Regression tests for custom MegaLinter descriptor command shapes."""
+
+from pathlib import Path
+
+import yaml
+
+
+def test_dclint_receives_compose_files_without_removed_subcommand() -> None:
+    descriptor = yaml.safe_load(Path("plugins/dclint.megalinter-descriptor.yml").read_text())
+    dclint = descriptor["linters"][0]
+
+    assert dclint["cli_lint_mode"] == "list_of_files"
+    assert dclint["cli_lint_extra_args"] == []


### PR DESCRIPTION
## What changed
- run the DCLint 3.1 plugin in MegaLinter list-of-files mode
- remove the obsolete `lint .` command shape
- add a regression test for the descriptor contract

## Root cause
DCLint 3.1 accepts Compose files directly. The custom descriptor used `dclint lint .`, so DCLint treated `lint` as a path and performed no validation. Because Homelab marks DCLint non-blocking, the failed invocation appeared as a warning in an otherwise successful run.

## Validation
- `uv run pytest -q test/test_plugin_descriptors.py test/test_check_image_integrity.py`
- `just check`
- `just build`
- built-image run against Homelab origin/main analyzed 54 Compose files with `dclint <files...>` and reported real Compose findings; no `FileNotFoundError` remained