### PR TITLE
feat: require canonical consumer linter configs

### DIFF
--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -77,6 +77,20 @@ use the configs baked into the image. Keep only `.mega-linter.yml` at the repo
 root and place linter-owned files such as `ruff.toml`, `.yamllint`,
 `.shellcheckrc`, and `.gitleaks.toml` in `quality/lint/`.
 
+Repositories that require particular overrides can make that contract fail
+closed by listing their MegaLinter config keys:
+
+```yaml
+CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS:
+  - BASH_SHELLCHECK_CONFIG_FILE
+  - PYTHON_RUFF_CONFIG_FILE
+  - YAML_YAMLLINT_CONFIG_FILE
+```
+
+The entrypoint removes this coding-standards-only setting before MegaLinter
+starts. It fails if any listed key does not resolve to an existing file below
+`LINTER_RULES_PATH`. Unlisted linters continue to use the baked baseline.
+
 `.editorconfig` is the deliberate exception. It is a repository-wide editor
 standard whose discovery protocol requires it in the directory tree, not a
 MegaLinter-only config file.

--- a/docs/help/override.md
+++ b/docs/help/override.md
@@ -13,4 +13,13 @@ the baseline default, declare only that override:
 ACTION_ACTIONLINT_CONFIG_FILE: actionlint.yaml
 ```
 
+Require important repository overrides to remain local instead of silently
+falling back to the baked baseline:
+
+```yaml
+CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS:
+  - ACTION_ACTIONLINT_CONFIG_FILE
+  - PYTHON_RUFF_CONFIG_FILE
+```
+
 Run `just cs-show-config` to see what each linter uses.

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -121,6 +121,9 @@ def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[s
         message = "LINTER_RULES_PATH must be a non-empty directory path"
         raise ValueError(message)
     if rules_path.startswith("http") or Path(rules_path).is_absolute():
+        if required is not None:
+            message = f"{REQUIRED_LOCAL_CONFIGS_KEY} requires a workspace-relative LINTER_RULES_PATH"
+            raise ValueError(message)
         merged["LINTER_RULES_PATH"] = rules_path
         return
 

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -22,6 +22,7 @@ import yaml
 SCRIPTS = Path("/opt/coding-standards/scripts")
 BAKED_CONFIG = Path("/opt/coding-standards/.mega-linter-default.yml")
 EXTENDS_URL = "https://raw.githubusercontent.com/alxleo/coding-standards/main/.mega-linter-default.yml"
+REQUIRED_LOCAL_CONFIGS_KEY = "CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS"
 
 app = typer.Typer(
     name="coding-standards",
@@ -72,6 +73,33 @@ def _warn_for_missing_overrides(overrides: dict[str, object], workspace: Path, r
             typer.echo(f"Warning: {key} override points to missing file: {value}", err=True)
 
 
+def _validate_required_local_configs(
+    merged: dict[str, object], required: object, workspace: Path, rules_directory: Path
+) -> None:
+    if required is None:
+        return
+    if not isinstance(required, list) or not all(isinstance(key, str) for key in required):
+        message = f"{REQUIRED_LOCAL_CONFIGS_KEY} must be a list of _CONFIG_FILE keys"
+        raise ValueError(message)
+
+    errors: list[str] = []
+    for key in required:
+        if not key.endswith("_CONFIG_FILE"):
+            errors.append(f"{key}: expected a _CONFIG_FILE key")
+            continue
+        value = merged.get(key)
+        if not isinstance(value, str):
+            errors.append(f"{key}: no effective config is declared")
+            continue
+        resolved = (workspace / value).resolve() if not Path(value).is_absolute() else Path(value).resolve()
+        if not resolved.is_relative_to(rules_directory) or not resolved.is_file():
+            errors.append(f"{key}: {value} is not a file under {rules_directory.relative_to(workspace)}")
+
+    if errors:
+        message = "Required local linter configs did not resolve:\n- " + "\n- ".join(errors)
+        raise ValueError(message)
+
+
 def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[str, object], workspace: Path) -> None:
     """Overlay a consumer LINTER_RULES_PATH without hiding baked configs.
 
@@ -81,8 +109,13 @@ def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[s
     avoids MegaLinter v9.6's root-first search order and absolute-path
     activation bug.
     """
+    required = overrides.pop(REQUIRED_LOCAL_CONFIGS_KEY, None)
+    merged.pop(REQUIRED_LOCAL_CONFIGS_KEY, None)
     rules_path = overrides.pop("LINTER_RULES_PATH", None)
     if rules_path is None:
+        if required is not None:
+            message = f"{REQUIRED_LOCAL_CONFIGS_KEY} requires LINTER_RULES_PATH"
+            raise ValueError(message)
         return
     if not isinstance(rules_path, str) or not rules_path.strip():
         message = "LINTER_RULES_PATH must be a non-empty directory path"
@@ -94,6 +127,7 @@ def _apply_consumer_rules_directory(merged: dict[str, object], overrides: dict[s
     rules_directory = _local_rules_directory(rules_path, workspace)
     _select_matching_consumer_configs(merged, overrides, rules_path, rules_directory)
     _warn_for_missing_overrides(overrides, workspace, rules_directory)
+    _validate_required_local_configs(merged, required, workspace, rules_directory)
 
 
 def _setup() -> None:
@@ -246,8 +280,8 @@ def warnings() -> None:
     subprocess.run(["python3", str(SCRIPTS / "show_warnings.py")], check=True)
 
 
-@app.command(name="show-config")
-def show_config() -> None:
+@app.command(name="show-config", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def show_config(ctx: typer.Context) -> None:
     """Show which config file each linter uses + local overrides."""
     os.chdir(_workspace())
     subprocess.run(
@@ -257,6 +291,7 @@ def show_config() -> None:
             ".",
             "--mega-linter-yml",
             os.environ.get("MEGALINTER_CONFIG", str(BAKED_CONFIG)),
+            *ctx.args,
         ],
         check=True,
     )

--- a/scripts/generate_repo_manifest.py
+++ b/scripts/generate_repo_manifest.py
@@ -311,6 +311,22 @@ def extract_extends_url(root: Path) -> str | None:
     return None
 
 
+def linter_rules_root(root: Path) -> Path:
+    """Return the safe workspace-local rules directory selected by MegaLinter."""
+    config = root / ".mega-linter.yml"
+    if not config.is_file():
+        return root
+    try:
+        data = yaml.safe_load(config.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return root
+    rules_path = data.get("LINTER_RULES_PATH") if isinstance(data, dict) else None
+    if not isinstance(rules_path, str) or not rules_path.strip() or Path(rules_path).is_absolute():
+        return root
+    candidate = (root / rules_path).resolve()
+    return candidate if candidate.is_relative_to(root.resolve()) else root
+
+
 def check_gitignore_covers(root: Path, pattern: str) -> bool:
     gi = root / ".gitignore"
     if not gi.exists():
@@ -563,12 +579,13 @@ def _count_suppressions(root: Path, inventory: WorkspaceInventory) -> dict[str, 
         for name, pattern in patterns.items():
             counts[name] += len(re.findall(pattern, text))
     # File-level suppressions
-    counts["trivyignore"] = (
-        len((root / ".trivyignore").read_text().splitlines()) if (root / ".trivyignore").exists() else 0
+    rules_root = linter_rules_root(root)
+    trivy_ignore = next(
+        (path for name in (".trivyignore", ".trivyignore.yaml") if (path := rules_root / name).is_file()), None
     )
-    counts["gitleaksignore"] = (
-        len((root / ".gitleaksignore").read_text().splitlines()) if (root / ".gitleaksignore").exists() else 0
-    )
+    gitleaks_ignore = rules_root / ".gitleaksignore"
+    counts["trivyignore"] = len(trivy_ignore.read_text().splitlines()) if trivy_ignore else 0
+    counts["gitleaksignore"] = len(gitleaks_ignore.read_text().splitlines()) if gitleaks_ignore.is_file() else 0
     counts["total"] = sum(counts.values())
     return counts
 
@@ -578,20 +595,21 @@ def generate(root: Path) -> dict[str, Any]:
 
     inventory = WorkspaceInventory.build(root)
     ack = load_acknowledged(root)
+    rules_root = linter_rules_root(root)
     data = {
         "files": {
-            "pyrightconfig": (root / "pyrightconfig.json").exists(),
-            "ruff": (root / "ruff.toml").exists(),
-            "gitleaks": (root / ".gitleaks.toml").exists(),
+            "pyrightconfig": (rules_root / "pyrightconfig.json").exists(),
+            "ruff": (rules_root / "ruff.toml").exists(),
+            "gitleaks": (rules_root / ".gitleaks.toml").exists(),
             "sops": (root / ".sops.yaml").exists(),
-            "trivy": (root / "trivy.yaml").exists(),
+            "trivy": (rules_root / "trivy.yaml").exists(),
             "mega_linter": (root / ".mega-linter.yml").exists(),
             "mega_linter_extends_url": extract_extends_url(root),
-            "conftest_toml": (root / "conftest.toml").exists(),
+            "conftest_toml": (rules_root / "conftest.toml").exists() or (root / "conftest.toml").exists(),
             "editorconfig": (root / ".editorconfig").exists(),
             "tsconfig": (root / "tsconfig.json").exists(),
             "eslint_config": any(
-                (root / f).exists()
+                (rules_root / f).exists()
                 for f in [
                     "eslint.config.js",
                     "eslint.config.mjs",
@@ -600,9 +618,10 @@ def generate(root: Path) -> dict[str, Any]:
                     ".eslintrc.yml",
                 ]
             ),
-            "pre_commit_config": (root / ".pre-commit-config.yaml").exists(),
+            "pre_commit_config": (root / ".pre-commit-config.yaml").exists()
+            or (rules_root / ".pre-commit-config.yaml").exists(),
             "commitlint_config": any(
-                (root / f).exists()
+                (rules_root / f).exists()
                 for f in [
                     "commitlint.config.js",
                     "commitlint.config.mjs",

--- a/scripts/generate_repo_manifest.py
+++ b/scripts/generate_repo_manifest.py
@@ -584,7 +584,16 @@ def _count_suppressions(root: Path, inventory: WorkspaceInventory) -> dict[str, 
         (path for name in (".trivyignore", ".trivyignore.yaml") if (path := rules_root / name).is_file()), None
     )
     gitleaks_ignore = rules_root / ".gitleaksignore"
-    counts["trivyignore"] = len(trivy_ignore.read_text().splitlines()) if trivy_ignore else 0
+    if trivy_ignore and trivy_ignore.suffix == ".yaml":
+        trivy_data = yaml.safe_load(trivy_ignore.read_text())
+        if isinstance(trivy_data, dict):
+            counts["trivyignore"] = sum(len(entries) for entries in trivy_data.values() if isinstance(entries, list))
+        elif isinstance(trivy_data, list):
+            counts["trivyignore"] = len(trivy_data)
+        else:
+            counts["trivyignore"] = 0
+    else:
+        counts["trivyignore"] = len(trivy_ignore.read_text().splitlines()) if trivy_ignore else 0
     counts["gitleaksignore"] = len(gitleaks_ignore.read_text().splitlines()) if gitleaks_ignore.is_file() else 0
     counts["total"] = sum(counts.values())
     return counts

--- a/scripts/show_config.py
+++ b/scripts/show_config.py
@@ -112,12 +112,8 @@ def show_config(workspace: Path, yml_path: Path) -> list[dict[str, str]]:
             resolved_path = entry["config_path"]
         else:
             shadows = _find_shadows(workspace, entry["config_basename"])
-            if shadows:
-                source = "workspace"
-                resolved_path = shadows[0]
-            else:
-                source = "baseline"
-                resolved_path = entry["config_path"]
+            source = "baseline"
+            resolved_path = entry["config_path"]
         tier = "warn" if linter in warn_linters else "error"
         rows.append(
             {

--- a/scripts/show_config.py
+++ b/scripts/show_config.py
@@ -12,6 +12,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -95,7 +96,7 @@ def _find_shadows(workspace: Path, config_basename: str) -> list[str]:
 def show_config(workspace: Path, yml_path: Path) -> list[dict[str, str]]:
     """Build the config table rows.
 
-    Returns list of dicts with: linter, config_file, tier, shadow.
+    Returns list of dicts with: linter, config_file, tier, shadow, source, path.
     """
     data = _parse_yml(yml_path)
     entries = _extract_config_entries(data)
@@ -107,8 +108,16 @@ def show_config(workspace: Path, yml_path: Path) -> list[dict[str, str]]:
         selected_path = Path(entry["config_path"])
         if len(selected_path.parts) > 1 and not selected_path.is_absolute() and (workspace / selected_path).is_file():
             shadows = [entry["config_path"]]
+            source = "consumer"
+            resolved_path = entry["config_path"]
         else:
             shadows = _find_shadows(workspace, entry["config_basename"])
+            if shadows:
+                source = "workspace"
+                resolved_path = shadows[0]
+            else:
+                source = "baseline"
+                resolved_path = entry["config_path"]
         tier = "warn" if linter in warn_linters else "error"
         rows.append(
             {
@@ -116,6 +125,8 @@ def show_config(workspace: Path, yml_path: Path) -> list[dict[str, str]]:
                 "config_file": entry["config_basename"],
                 "tier": tier,
                 "shadow": ", ".join(shadows) if shadows else "",
+                "source": source,
+                "path": resolved_path,
             }
         )
     return rows
@@ -153,11 +164,15 @@ def main(argv: list[str] | None = None) -> int:
 
     workspace = Path()
     yml_path = Path(_DEFAULT_YML)
+    output_format = "table"
 
     i = 0
     while i < len(args):
         if args[i] == "--mega-linter-yml" and i + 1 < len(args):
             yml_path = Path(args[i + 1])
+            i += 2
+        elif args[i] == "--format" and i + 1 < len(args):
+            output_format = args[i + 1]
             i += 2
         else:
             workspace = Path(args[i])
@@ -168,7 +183,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     rows = show_config(workspace, yml_path)
-    _print_table(rows)
+    if output_format == "json":
+        print(json.dumps(rows, indent=2))
+    elif output_format == "table":
+        _print_table(rows)
+    else:
+        print(f"Unsupported format: {output_format}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/test/test_entrypoint_config.py
+++ b/test/test_entrypoint_config.py
@@ -181,3 +181,16 @@ class TestRulesDirectoryResolution:
 
         with pytest.raises(ValueError, match="not a file under quality/lint"):
             _run_setup()
+
+    @pytest.mark.parametrize("rules_path", ["/opt/custom", "https://example.com/configs"])
+    def test_required_local_configs_reject_non_local_rules_path(self, workspace, rules_path):
+        _write_consumer_config(
+            workspace,
+            {
+                "LINTER_RULES_PATH": rules_path,
+                "CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS": ["PYTHON_RUFF_CONFIG_FILE"],
+            },
+        )
+
+        with pytest.raises(ValueError, match="workspace-relative LINTER_RULES_PATH"):
+            _run_setup()

--- a/test/test_entrypoint_config.py
+++ b/test/test_entrypoint_config.py
@@ -135,3 +135,49 @@ class TestRulesDirectoryResolution:
         merged = _read_merged_config()
         assert merged["PYTHON_RUFF_RULES_PATH"] == "custom/ruff"
         assert merged["PYTHON_RUFF_CONFIG_FILE"] == "ruff.toml"
+
+    def test_required_local_configs_resolve_and_private_key_is_removed(self, workspace):
+        rules = workspace / "quality" / "lint"
+        rules.mkdir(parents=True)
+        (rules / "ruff.toml").write_text("[lint]\n")
+        _write_consumer_config(
+            workspace,
+            {
+                "LINTER_RULES_PATH": "quality/lint",
+                "CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS": ["PYTHON_RUFF_CONFIG_FILE"],
+            },
+        )
+
+        _run_setup()
+
+        merged = _read_merged_config()
+        assert merged["PYTHON_RUFF_CONFIG_FILE"] == "quality/lint/ruff.toml"
+        assert "CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS" not in merged
+
+    def test_required_local_config_missing_fails_closed(self, workspace):
+        (workspace / "quality" / "lint").mkdir(parents=True)
+        _write_consumer_config(
+            workspace,
+            {
+                "LINTER_RULES_PATH": "quality/lint",
+                "CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS": ["PYTHON_RUFF_CONFIG_FILE"],
+            },
+        )
+
+        with pytest.raises(ValueError, match="PYTHON_RUFF_CONFIG_FILE"):
+            _run_setup()
+
+    def test_required_local_config_rejects_root_override(self, workspace):
+        (workspace / "quality" / "lint").mkdir(parents=True)
+        (workspace / "ruff.toml").write_text("[lint]\n")
+        _write_consumer_config(
+            workspace,
+            {
+                "LINTER_RULES_PATH": "quality/lint",
+                "PYTHON_RUFF_CONFIG_FILE": "ruff.toml",
+                "CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS": ["PYTHON_RUFF_CONFIG_FILE"],
+            },
+        )
+
+        with pytest.raises(ValueError, match="not a file under quality/lint"):
+            _run_setup()

--- a/test/test_generate_repo_manifest.py
+++ b/test/test_generate_repo_manifest.py
@@ -83,7 +83,17 @@ def test_canonical_linter_rules_directory_is_manifest_authority(tmp_path: Path) 
     (rules / ".gitleaks.toml").write_text("[allowlist]\n")
     (rules / ".gitleaksignore").write_text("example\n")
     (rules / "trivy.yaml").write_text("scan: {}\n")
-    (rules / ".trivyignore.yaml").write_text("- id: example\n")
+    (rules / ".trivyignore.yaml").write_text(
+        "vulnerabilities:\n"
+        "  - id: CVE-2026-0001\n"
+        "    paths:\n"
+        "      - usr/lib/example\n"
+        "    statement: accepted risk\n"
+        "secrets:\n"
+        "  - id: generic-api-key\n"
+        "    paths:\n"
+        "      - test/fixture.txt\n"
+    )
     (rules / "commitlint.config.mjs").write_text("export default {};\n")
 
     manifest = generate(tmp_path)
@@ -94,7 +104,7 @@ def test_canonical_linter_rules_directory_is_manifest_authority(tmp_path: Path) 
     assert manifest["files"]["trivy"] is True
     assert manifest["files"]["commitlint_config"] is True
     assert manifest["suppressions"]["gitleaksignore"] == 1
-    assert manifest["suppressions"]["trivyignore"] == 1
+    assert manifest["suppressions"]["trivyignore"] == 2
 
 
 def test_js_repo_detects_files(js_repo: Path) -> None:

--- a/test/test_generate_repo_manifest.py
+++ b/test/test_generate_repo_manifest.py
@@ -74,6 +74,29 @@ def test_python_repo_detects_files(python_repo: Path) -> None:
     assert manifest["dependencies"]["test_deps_defined"] is True
 
 
+def test_canonical_linter_rules_directory_is_manifest_authority(tmp_path: Path) -> None:
+    rules = tmp_path / "quality" / "lint"
+    rules.mkdir(parents=True)
+    (tmp_path / ".mega-linter.yml").write_text("LINTER_RULES_PATH: quality/lint\n")
+    (rules / "ruff.toml").write_text("[lint]\n")
+    (rules / "pyrightconfig.json").write_text("{}\n")
+    (rules / ".gitleaks.toml").write_text("[allowlist]\n")
+    (rules / ".gitleaksignore").write_text("example\n")
+    (rules / "trivy.yaml").write_text("scan: {}\n")
+    (rules / ".trivyignore.yaml").write_text("- id: example\n")
+    (rules / "commitlint.config.mjs").write_text("export default {};\n")
+
+    manifest = generate(tmp_path)
+
+    assert manifest["files"]["ruff"] is True
+    assert manifest["files"]["pyrightconfig"] is True
+    assert manifest["files"]["gitleaks"] is True
+    assert manifest["files"]["trivy"] is True
+    assert manifest["files"]["commitlint_config"] is True
+    assert manifest["suppressions"]["gitleaksignore"] == 1
+    assert manifest["suppressions"]["trivyignore"] == 1
+
+
 def test_js_repo_detects_files(js_repo: Path) -> None:
     manifest = generate(js_repo)
     assert manifest["content"]["typescript_files"] == 1

--- a/test/test_show_config.py
+++ b/test/test_show_config.py
@@ -6,6 +6,7 @@ Uses tmp_path fixtures to simulate workspace dirs with/without shadowing configs
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -132,6 +133,8 @@ class TestShowConfig:
 
         ruff_row = next(r for r in rows if r["linter"] == "PYTHON_RUFF")
         assert ruff_row["shadow"] == "quality/lint/ruff.toml"
+        assert ruff_row["source"] == "consumer"
+        assert ruff_row["path"] == "quality/lint/ruff.toml"
 
     def test_tier_classification(self, empty_workspace: Path, sample_yml: Path) -> None:
         rows = show_config(empty_workspace, sample_yml)
@@ -172,3 +175,12 @@ class TestMain:
         captured = capsys.readouterr()
         assert "3 linters with baked configs" in captured.out
         assert "1 overridden locally" in captured.out
+
+    def test_json_output_reports_config_source(
+        self, empty_workspace: Path, sample_yml: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        result = main([str(empty_workspace), "--mega-linter-yml", str(sample_yml), "--format", "json"])
+
+        assert result == 0
+        rows = json.loads(capsys.readouterr().out)
+        assert rows[0]["source"] == "baseline"

--- a/test/test_show_config.py
+++ b/test/test_show_config.py
@@ -120,6 +120,18 @@ class TestShowConfig:
         rows = show_config(workspace_with_ruff, sample_yml)
         ruff_row = next(r for r in rows if r["linter"] == "PYTHON_RUFF")
         assert "ruff.toml" in ruff_row["shadow"]
+        assert ruff_row["source"] == "baseline"
+        assert ruff_row["path"] == "/opt/coding-standards/configs/ruff.toml"
+
+    def test_alternate_shadow_is_not_reported_as_selected(self, empty_workspace: Path, sample_yml: Path) -> None:
+        (empty_workspace / "pyproject.toml").write_text("[tool.ruff]\n")
+
+        rows = show_config(empty_workspace, sample_yml)
+
+        ruff_row = next(r for r in rows if r["linter"] == "PYTHON_RUFF")
+        assert ruff_row["shadow"] == "pyproject.toml"
+        assert ruff_row["source"] == "baseline"
+        assert ruff_row["path"] == "/opt/coding-standards/configs/ruff.toml"
 
     def test_detects_selected_rules_directory_config(self, empty_workspace: Path, sample_yml: Path) -> None:
         rules = empty_workspace / "quality" / "lint"


### PR DESCRIPTION
## What changed
- add `CODING_STANDARDS_REQUIRED_LOCAL_CONFIGS` as a fail-closed consumer contract
- reject required configs that are missing or resolve outside `LINTER_RULES_PATH`
- remove the private contract key before starting MegaLinter
- add JSON config-source output to `show-config`
- make repo-manifest config and suppression detection honor the canonical rules directory
- document downstream usage

## Why
The centralized overlay intentionally falls back to baked configs. That keeps consumers working, but an accidentally deleted repository override could silently change policy. Consumers can now name the overrides that must remain local while leaving uncustomized linters on the baseline.

## Validation
- 57 focused config/manifest tests passed
- `just check`
- missing and root-only required configs fail closed
- canonical configs are reported as `source: consumer` in JSON output