### PR TITLE
feat: scan secrets with Betterleaks history mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         id: ctx
         env:
           # hashFiles() is a GHA expression — hash all files baked into the image.
-          CTX_HASH: ctx-${{ hashFiles('Dockerfile', 'plugins/**', 'semgrep-rules/**', 'policies/**', 'scripts/entrypoint.py', 'scripts/ci/**', 'scripts/show_catalog.py', 'scripts/generate_rule_catalog.py', 'scripts/generate_repo_manifest.py', 'scripts/manifest_schema.py', 'scripts/show_config.py', 'scripts/show_warnings.py', 'scripts/blast_radius.py', 'scripts/megalinter_report_statuses.py', 'scripts/download_build_assets.py', 'scripts/recommend.py', 'build-assets.yml', 'lint-configs/**', 'docs/help/**', 'consumer.just', 'templates/**', '.mega-linter-default.yml') }}
+          CTX_HASH: ctx-${{ hashFiles('Dockerfile', 'plugins/**', 'semgrep-rules/**', 'policies/**', 'scripts/entrypoint.py', 'scripts/betterleaks_git.sh', 'scripts/ci/**', 'scripts/show_catalog.py', 'scripts/generate_rule_catalog.py', 'scripts/generate_repo_manifest.py', 'scripts/manifest_schema.py', 'scripts/show_config.py', 'scripts/show_warnings.py', 'scripts/blast_radius.py', 'scripts/megalinter_report_statuses.py', 'scripts/download_build_assets.py', 'scripts/recommend.py', 'build-assets.yml', 'lint-configs/**', 'docs/help/**', 'consumer.just', 'templates/**', '.mega-linter-default.yml') }}
         run: |
           # Truncate to ctx- prefix + 16 hex chars for tag readability
           SHORT="${CTX_HASH:0:20}"

--- a/.mega-linter-default.yml
+++ b/.mega-linter-default.yml
@@ -38,7 +38,7 @@ ENABLE_LINTERS:
   # Links
   - SPELL_LYCHEE
   # Secrets
-  - REPOSITORY_GITLEAKS
+  - REPOSITORY_BETTERLEAKS_GIT
   # Security (SAST)
   - REPOSITORY_SEMGREP
   # Security (vuln + IaC)
@@ -180,7 +180,7 @@ JSON_PRETTIER_CONFIG_FILE: .prettierrc
 YAML_PRETTIER_CONFIG_FILE: .prettierrc
 JAVASCRIPT_PRETTIER_CONFIG_FILE: .prettierrc
 TYPESCRIPT_PRETTIER_CONFIG_FILE: .prettierrc
-REPOSITORY_GITLEAKS_CONFIG_FILE: .gitleaks.toml
+REPOSITORY_BETTERLEAKS_GIT_CONFIG_FILE: .gitleaks.toml
 # editorconfig-checker: _CONFIG_FILE expects an .ecrc (tool config), not .editorconfig.
 # The tool auto-discovers .editorconfig from the workspace root (copied via PRE_COMMANDS).
 SPELL_CODESPELL_CONFIG_FILE: .codespellrc
@@ -322,6 +322,7 @@ POST_COMMANDS:
 
 # ── Plugins (custom tools baked into image) ───────────────────
 PLUGINS:
+  - "file:///mega-linter-plugin-custom/betterleaks-git.megalinter-descriptor.yml"
   - "file:///mega-linter-plugin-custom/commitlint.megalinter-descriptor.yml"
   - "file:///mega-linter-plugin-custom/trivy.megalinter-descriptor.yml"
   - "file:///mega-linter-plugin-custom/dclint.megalinter-descriptor.yml"

--- a/Dockerfile
+++ b/Dockerfile
@@ -329,6 +329,7 @@ COPY policies/ /opt/coding-standards/policies/
 
 # ── Mechanism scripts + reporting ─────────────────────────────
 COPY --chmod=755 scripts/ci/check_expiry.py scripts/megalinter_report_statuses.py scripts/generate_repo_manifest.py scripts/show_catalog.py scripts/manifest_schema.py scripts/show_warnings.py scripts/blast_radius.py scripts/show_config.py scripts/recommend.py /opt/coding-standards/scripts/
+COPY --chmod=755 scripts/betterleaks_git.sh /usr/local/bin/betterleaks-git
 
 # ── Linter config files ──────────────────────────────────────
 COPY lint-configs/ /opt/coding-standards/configs/

--- a/docs/config-decisions.md
+++ b/docs/config-decisions.md
@@ -28,10 +28,11 @@ Decisions made 2026-03-29. Revisit if assumptions change.
 - syft: no SBOM consumer.
 - Trivy is checksum-pinned to a post-incident release. MegaLinter re-enabled Trivy after the upstream incident was resolved.
 
-### Secrets: Gitleaks in CI; Betterleaks available for opt-in trials
+### Secrets: Betterleaks with full Git history
 
-- Gitleaks remains the default because it scans repository history. MegaLinter v9.6 invokes Betterleaks in filesystem mode by default, which would miss secrets removed from the final working tree but retained in earlier commits.
-- Betterleaks remains installed for explicit consumer trials; it accepts existing `.gitleaks.toml` and `.gitleaksignore` files.
+- `REPOSITORY_BETTERLEAKS_GIT` is the default. It wraps Betterleaks in `git` mode because MegaLinter v9.6's built-in `REPOSITORY_BETTERLEAKS` uses filesystem mode and misses secrets removed from the current tree.
+- The wrapper preserves existing `.gitleaks.toml` and `.gitleaksignore` files. When a selected config lives in a canonical rules directory, the sibling ignore file is passed automatically.
+- Gitleaks remains installed temporarily for consumers that have not migrated, but it is no longer enabled by the baseline.
 - secretlint: strict subset of Gitleaks coverage.
 - trufflehog: valuable for `--only-verified` audits. Use as periodic cron, not CI.
 

--- a/docs/help/suppress.md
+++ b/docs/help/suppress.md
@@ -13,7 +13,7 @@ Type ignore:       # type: ignore[arg-type]
 
 ```
 Trivy:     .trivyignore          (CVE IDs)
-Gitleaks:  .gitleaksignore       (path patterns)
+Betterleaks: .gitleaksignore     (compatible fingerprints and paths)
 Codespell: .codespellrc          (word whitelist)
 ```
 

--- a/lint-configs/.gitleaks.toml
+++ b/lint-configs/.gitleaks.toml
@@ -1,8 +1,8 @@
-# Gitleaks baseline — synced to all repos.
-# Each repo adds its own .gitleaks.toml at the root for allowlists.
-# https://github.com/gitleaks/gitleaks
+# Betterleaks baseline using its Gitleaks-compatible format.
+# Consumer configs and sibling .gitleaksignore files may live under LINTER_RULES_PATH.
+# https://github.com/betterleaks/betterleaks
 
-title = "coding-standards gitleaks baseline"
+title = "coding-standards Betterleaks baseline"
 
 [extend]
 useDefault = true

--- a/plugins/betterleaks-git.megalinter-descriptor.yml
+++ b/plugins/betterleaks-git.megalinter-descriptor.yml
@@ -1,0 +1,32 @@
+descriptor_id: REPOSITORY
+descriptor_type: other
+lint_all_files: true
+linters:
+  - linter_name: betterleaks-git
+    name: REPOSITORY_BETTERLEAKS_GIT
+    descriptor_flavors:
+      - cupcake
+    cli_lint_mode: project
+    linter_text: Scan full Git history for secrets with Betterleaks
+    linter_url: https://github.com/betterleaks/betterleaks
+    cli_executable: betterleaks-git
+    cli_lint_extra_args:
+      - git
+      - --redact
+      - --verbose
+    cli_lint_extra_args_after:
+      - .
+    cli_config_arg_name: "--config"
+    cli_help_arg_name: --help
+    cli_version_arg_name: version
+    config_file_name: .gitleaks.toml
+    can_output_sarif: true
+    cli_sarif_args:
+      - --report-format
+      - sarif
+      - --report-path
+      - "{{SARIF_OUTPUT_FILE}}"
+    cli_lint_errors_count: regex_sum
+    cli_lint_errors_regex: "leaks found: ([0-9]+)"
+    files_sub_directory: ""
+    file_extensions: []

--- a/scripts/betterleaks_git.sh
+++ b/scripts/betterleaks_git.sh
@@ -28,4 +28,12 @@ if [[ -n "$config_file" && "$has_ignore_path" == false ]]; then
   fi
 fi
 
+# Betterleaks shells out to Git but does not reliably consume MegaLinter's
+# global safe.directory setting on runner-owned bind mounts. Pass the workspace
+# as command-scope Git configuration inherited by the child process.
+git_config_index="${GIT_CONFIG_COUNT:-0}"
+export "GIT_CONFIG_KEY_${git_config_index}=safe.directory"
+export "GIT_CONFIG_VALUE_${git_config_index}=$(pwd -P)"
+export GIT_CONFIG_COUNT="$((git_config_index + 1))"
+
 exec betterleaks "${args[@]}"

--- a/scripts/betterleaks_git.sh
+++ b/scripts/betterleaks_git.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=("$@")
+config_file=""
+has_ignore_path=false
+
+for ((index = 0; index < ${#args[@]}; index++)); do
+  case "${args[index]}" in
+    -c | --config)
+      if ((index + 1 < ${#args[@]})); then
+        config_file="${args[index + 1]}"
+      fi
+      ;;
+    --config=*)
+      config_file="${args[index]#*=}"
+      ;;
+    -i | --gitleaks-ignore-path | --gitleaks-ignore-path=*)
+      has_ignore_path=true
+      ;;
+  esac
+done
+
+if [[ -n "$config_file" && "$has_ignore_path" == false ]]; then
+  ignore_file="$(dirname -- "$config_file")/.gitleaksignore"
+  if [[ -f "$ignore_file" ]]; then
+    args+=(--gitleaks-ignore-path "$ignore_file")
+  fi
+fi
+
+exec betterleaks "${args[@]}"

--- a/scripts/hooks/check-image-integrity
+++ b/scripts/hooks/check-image-integrity
@@ -166,6 +166,7 @@ BUILTIN_EXES = {
 # Package name → binary name aliases
 INSTALL_ALIASES = {
     "attw": "@arethetypeswrong/cli",
+    "betterleaks-git": "betterleaks",
     "depcruise": "dependency-cruiser",
     "lint-imports": "import-linter",
     "tsc": "typescript",

--- a/test/test_plugin_descriptors.py
+++ b/test/test_plugin_descriptors.py
@@ -11,3 +11,14 @@ def test_dclint_receives_compose_files_without_removed_subcommand() -> None:
 
     assert dclint["cli_lint_mode"] == "list_of_files"
     assert dclint["cli_lint_extra_args"] == []
+
+
+def test_betterleaks_scans_git_history_with_compatible_config() -> None:
+    descriptor = yaml.safe_load(Path("plugins/betterleaks-git.megalinter-descriptor.yml").read_text())
+    betterleaks = descriptor["linters"][0]
+
+    assert betterleaks["name"] == "REPOSITORY_BETTERLEAKS_GIT"
+    assert betterleaks["cli_lint_mode"] == "project"
+    assert betterleaks["cli_lint_extra_args"][0] == "git"
+    assert betterleaks["config_file_name"] == ".gitleaks.toml"
+    assert betterleaks["cli_lint_extra_args_after"] == ["."]

--- a/test/test_plugin_descriptors.py
+++ b/test/test_plugin_descriptors.py
@@ -22,3 +22,7 @@ def test_betterleaks_scans_git_history_with_compatible_config() -> None:
     assert betterleaks["cli_lint_extra_args"][0] == "git"
     assert betterleaks["config_file_name"] == ".gitleaks.toml"
     assert betterleaks["cli_lint_extra_args_after"] == ["."]
+
+    wrapper = Path("scripts/betterleaks_git.sh").read_text()
+    assert "GIT_CONFIG_KEY_${git_config_index}=safe.directory" in wrapper
+    assert "GIT_CONFIG_VALUE_${git_config_index}=$(pwd -P)" in wrapper


### PR DESCRIPTION
## Summary
- replace deprecated Gitleaks baseline with a Betterleaks plugin that scans full Git history
- preserve compatible `.gitleaks.toml` and sibling `.gitleaksignore` files under `LINTER_RULES_PATH`
- include the wrapper in image cache invalidation and integrity checks

## Validation
- `just check`
- local image build
- Homelab exact-main scan: 0 findings, 5.39s, config from `quality/lint/.gitleaks.toml`
- two-commit oracle: filesystem mode 0 findings; Git mode 1 history-only finding
- Betterleaks 1.7.3 and Gitleaks 8.30.1 both returned 0 on Homelab history; native timings 5.11s and 5.02s respectively